### PR TITLE
Make Point a pure swift class

### DIFF
--- a/SwiftApp/SwiftApp/Lap.swift
+++ b/SwiftApp/SwiftApp/Lap.swift
@@ -4,7 +4,7 @@
 
 import UIKit
 
-final class Lap: NSObject {
+final class Lap {
   
   let GATE_RANGE: Double = 100
   

--- a/SwiftApp/SwiftApp/Point.swift
+++ b/SwiftApp/SwiftApp/Point.swift
@@ -16,7 +16,7 @@ func == (left: Point, right: Point) -> Bool {
   return (left.latitudeDegrees() == right.latitudeDegrees()) && (left.longitudeDegrees() == right.longitudeDegrees())
 }
 
-class Point: NSObject, Equatable, Printable {
+class Point: Equatable {
   
   let RADIUS: Double = 6371000
   


### PR DESCRIPTION
Making the Point class a pure swift class (that does not inherit from NSObject)  makes the swift version of the app much faster. 